### PR TITLE
Disable compilation of Redis extensions

### DIFF
--- a/docker/phpfpm/Dockerfile
+++ b/docker/phpfpm/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 
 RUN yes | pecl update-channels
 
-RUN yes | pecl install igbinary redis xdebug
+RUN pecl install igbinary redis xdebug
 
 RUN docker-php-ext-install intl && \
     docker-php-ext-install gd && \


### PR DESCRIPTION
The Redis extension wasn't compiling because `yes` caused `pecl` to attempt to compile support for all extensions: some of which would not build.