### PR TITLE
Remove all references to prototype LTI platform

### DIFF
--- a/.env
+++ b/.env
@@ -16,5 +16,4 @@ LTI1P3_SERVICE_ENCRYPTION_KEY=a725e29c19dabee77hdccb90a3f84db04
 ###> Schoolbox tool/platform configuration ###
 SCHOOLBOX_PLATFORM_PUBLICKEY=""
 SCHOOLBOX_REGISTRATION_DEPLOYMENT_ID=""
-SCHOOLBOX_REGISTRATION_PROTOTYPE_DEPLOYMENT_ID=""
 ###< schoolbox tool/platform configuration ###

--- a/.env.local.default
+++ b/.env.local.default
@@ -18,8 +18,4 @@ SCHOOLBOX_PLATFORM_PUBLIC_KEY=""
 ### Paste Deployment ID from the "Devkit" Schoolbox LTI Provider.
 SCHOOLBOX_REGISTRATION_DEPLOYMENT_ID=""
 
-### Registration Deployment ID:
-### Paste Deployment ID from the "Devkit Prototype" Schoolbox LTI Provider.
-SCHOOLBOX_REGISTRATION_PROTOTYPE_DEPLOYMENT_ID=""
-
 ###< schoolbox tool/platform configuration ###

--- a/config/packages/lti1p3.yaml
+++ b/config/packages/lti1p3.yaml
@@ -32,10 +32,6 @@ lti1p3:
             audience: "%env(resolve:SCHOOLBOX_PLATFORM_HOST)%"
             oidc_authentication_url: "%env(resolve:SCHOOLBOX_PLATFORM_HOST)%/lti-platform/oidc/authentication"
             oauth2_access_token_url: "%env(resolve:SCHOOLBOX_PLATFORM_HOST)%/lti-platform/auth/token"
-        schoolboxPrototypePlatform:
-            name: "Schoolbox LTI Prototype"
-            audience: "%env(resolve:SCHOOLBOX_PLATFORM_HOST)%"
-            oidc_authentication_url: "%env(resolve:SCHOOLBOX_PLATFORM_HOST)%/lti-prototype/platform/oidc/authentication"
     tools:
         devkitTool:
             name: "LTI 1.3 DevKit (as tool)"
@@ -68,15 +64,3 @@ lti1p3:
             platform_jwks_url: "%env(resolve:SCHOOLBOX_PLATFORM_HOST)%/lti-platform/.well-known/jwks.json"
             tool_jwks_url: "%application_host%/lti1p3/.well-known/jwks/toolSet.json"
             order: 2
-        schoolboxPrototype:
-            client_id: "%env(resolve:SCHOOLBOX_REGISTRATION_PROTOTYPE_DEPLOYMENT_ID)%"
-            platform: "schoolboxPrototypePlatform"
-            tool: "devkitTool"
-            deployment_ids:
-                - '%env(resolve:SCHOOLBOX_REGISTRATION_PROTOTYPE_DEPLOYMENT_ID)%'
-            # Uncomment the below line to use the keychain's public key directly
-            #platform_key_chain: "schoolboxPlatformKey"
-            tool_key_chain: "toolKey"
-            platform_jwks_url: "%env(resolve:SCHOOLBOX_PLATFORM_HOST)%/lti-platform/.well-known/jwks.json"
-            tool_jwks_url: "%application_host%/lti1p3/.well-known/jwks/toolSet.json"
-            order: 3


### PR DESCRIPTION
This is no longer required (its only purpose was to explore how the communication between Schoolbox and an LTI tool worked), and only serves to confuse.